### PR TITLE
Update plotly.js

### DIFF
--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -50,7 +50,7 @@ HTMLWidgets.widget({
           var tr = x.data[pt.curveNumber];
           // add on additional trace info, if it exists
           attachKey = function(keyName) {
-            if (tr.hasOwnProperty(keyName) && tr[keyName] !== null) {
+            if (tr !== undefined && tr.hasOwnProperty(keyName) && tr[keyName] !== null) {
               if (typeof pt.pointNumber === "number") {
                 obj[keyName] = tr[keyName][pt.pointNumber];
               } else {


### PR DESCRIPTION
Solve "plotly.js:53Uncaught TypeError: Cannot read property 'hasOwnProperty' of undefined" on the browser for pie charts